### PR TITLE
Update radl.php

### DIFF
--- a/radl.php
+++ b/radl.php
@@ -59,7 +59,7 @@ if ( !class_exists( 'RADL' ) ) {
         private static function autoloader( $class_name )
         {
             if ( strpos( $class_name, 'RADL' ) === 0 ) {
-                require plugin_dir_path( __DIR__ ) . str_replace( '\\', '/', str_replace( '_', '-', str_replace( 'radl', 'rest-api-data-localizer', strtolower( $class_name ) ) ) ) . '.php';
+                require plugin_dir_path __DIR__ . str_replace( '\\', '/', str_replace( '_', '-', str_replace( 'radl', '', strtolower( $class_name ) ) ) ) . '.php';
             }
         }
 


### PR DESCRIPTION
Updated line 62 to properly declare the wp-plugin directory path. (There may be a more efficient way of doing this, but it works.)